### PR TITLE
Add Designer and Manufacturer Views to Session Page

### DIFF
--- a/cypress/e2e/sessions.cy.ts
+++ b/cypress/e2e/sessions.cy.ts
@@ -145,4 +145,57 @@ describe('Sessions Management', () => {
         cy.url({ timeout: 10000 }).should('include', '/dashboard')
         cy.contains('PROJECTS').should('be.visible')
     })
+
+    it('should toggle between Designer and Manufacturer views', () => {
+        const sessionTitle = `View Toggle Test ${Date.now()}`
+
+        // Mock Session with ID
+        cy.intercept('POST', '**/api/sessions', (req) => {
+            req.reply({
+                statusCode: 200,
+                body: { id: 'mock-session-view-id', title: req.body.title, project_id: 'mock-project-id', content: '' }
+            })
+        }).as('createSessionForView')
+
+        cy.intercept('GET', '**/api/sessions*', {
+            statusCode: 200,
+            body: [{ id: 'mock-session-view-id', title: sessionTitle }]
+        }).as('getSessionsForView')
+
+        cy.intercept('GET', '**/api/sessions/mock-session-view-id', {
+            statusCode: 200,
+            body: { id: 'mock-session-view-id', title: sessionTitle, status: 'pending', content: '' }
+        })
+
+        cy.intercept('GET', '**/api/blobs*', {
+            statusCode: 200,
+            body: []
+        })
+
+        cy.intercept('GET', '**/api/chat/messages*', {
+            statusCode: 200,
+            body: []
+        })
+
+        // Create Session
+        cy.contains('+ New Session').click()
+        cy.get('input[placeholder="Operation Name"]').type(sessionTitle)
+        cy.contains('button', 'Initialize').click()
+
+        // Verify Designer Mode (default)
+        // Note: Buttons are uppercase via CSS but text is "Designer" / "Manufacturer" in code.
+        // We can check case-insensitive or the exact text node.
+        cy.contains('Designer').should('be.visible')
+        cy.contains('Manufacturer').should('be.visible')
+
+        // Toggle to Manufacturer
+        cy.contains('Manufacturer').click()
+
+        // Check for Chat Interface presence (Secure-AI-Link text)
+        cy.contains('Secure-AI-Link').should('be.visible')
+
+        // Toggle back
+        cy.contains('Designer').click()
+        cy.contains('Secure-AI-Link').should('not.exist')
+    })
 })

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,9 +1,0 @@
-
-> interlock-frontend@0.0.0 dev
-> vite
-
-
-  VITE v5.4.21  ready in 397 ms
-
-  ➜  Local:   http://localhost:3000/
-  ➜  Network: http://192.168.0.2:3000/


### PR DESCRIPTION
Split the site into "Designer" and "Manufacturer" views to support distinct collaboration workflows. Designers can now comment on generated assets, while Manufacturers have access to an embedded AI chat interface alongside the file workbench. Comments are shared between views.

---
*PR created automatically by Jules for task [13094669636111709746](https://jules.google.com/task/13094669636111709746) started by @nathanalam*