### PR TITLE
Add 3D visualization prompting and rendering

### DIFF
--- a/src/components/ThreeJSRenderer.tsx
+++ b/src/components/ThreeJSRenderer.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+
+interface ThreeJSRendererProps {
+    code: string;
+}
+
+export function ThreeJSRenderer({ code }: ThreeJSRendererProps) {
+    const srcDoc = useMemo(() => {
+        // Simple escape for script tags to prevent breaking the HTML structure
+        const safeCode = code.replace(/<\/script>/g, '<\\/script>');
+
+        return `
+<!DOCTYPE html>
+<html>
+<head>
+    <style>body { margin: 0; overflow: hidden; background: transparent; }</style>
+    <!-- Load Three.js from CDN -->
+    <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+</head>
+<body>
+    <div id="container" style="width: 100vw; height: 100vh;"></div>
+    <script>
+        const container = document.getElementById('container');
+
+        window.onload = function() {
+            try {
+                if (!window.THREE) throw new Error("Three.js failed to load");
+
+                // Wrap in function to avoid global scope pollution
+                (function() {
+                    const THREE = window.THREE;
+                    // User Code Start
+                    ${safeCode}
+                    // User Code End
+                })();
+            } catch (e) {
+                document.body.innerHTML = '<div style="color: #ff6b6b; font-family: monospace; padding: 10px; font-size: 12px; background: rgba(0,0,0,0.8);">' + e.toString() + '</div>';
+                console.error(e);
+            }
+        };
+    </script>
+</body>
+</html>
+        `;
+    }, [code]);
+
+    return (
+        <div className="mt-4 border border-industrial-copper-500/30 bg-black/40 rounded-sm overflow-hidden relative group">
+            <div className="absolute top-0 left-0 px-2 py-1 bg-industrial-copper-500/20 border-b border-r border-industrial-copper-500/30 text-[9px] font-mono text-industrial-copper-500 uppercase tracking-widest z-10">
+                3D Viewport (Sandboxed)
+            </div>
+            <iframe
+                srcDoc={srcDoc}
+                className="w-full h-64 md:h-96 border-0"
+                sandbox="allow-scripts"
+                title="3D Visualization"
+            />
+            <div className="absolute bottom-0 right-0 p-2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                 <span className="text-[8px] font-mono text-industrial-steel-500">RENDERED WITH THREE.JS</span>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/SessionsPage.tsx
+++ b/src/pages/SessionsPage.tsx
@@ -4,6 +4,29 @@ import { ControllersSessionsService, ControllersProjectsService, ControllersBlob
 import { useAuth } from '../contexts/AuthContext';
 import { ChatInterface } from '../components/ChatInterface';
 
+const THREE_JS_SYSTEM_PROMPT = `
+[SYSTEM: 3D_VISUALIZATION_CAPABILITY]
+You are an AI assistant capable of generating 3D visualizations.
+If the user asks for a 3D figure, visualization, or model, generate JavaScript code using the 'three' library (available as 'THREE').
+The code should:
+1. Initialize a scene, camera, and renderer.
+2. Append the renderer's domElement to 'container' (a provided HTMLElement).
+3. Handle animation loop if necessary.
+4. Wrap the code in a markdown code block tagged 'javascript'.
+
+Example:
+\`\`\`javascript
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, container.clientWidth / container.clientHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(container.clientWidth, container.clientHeight);
+container.appendChild(renderer.domElement);
+// ... add objects ...
+function animate() { requestAnimationFrame(animate); renderer.render(scene, camera); }
+animate();
+\`\`\`
+`;
+
 export function SessionsPage() {
     const { projectId } = useParams<{ projectId: string }>();
     const [project, setProject] = useState<ProjectResponse | null>(null);
@@ -1082,7 +1105,12 @@ CRITICAL GENERAL INSTRUCTIONS FOR WORD DOCS (Ignore for Images):
                                         {(blobs.length === 0 && wizardStep === 1) ? renderEmptyState() : renderWorkbench()}
                                     </div>
                                     <div className="w-[400px] border-l border-industrial-concrete bg-industrial-steel-900/50 flex flex-col h-full border-l-2">
-                                        <ChatInterface sessionId={selectedSession.id} blobs={blobs} onRefreshBlobs={() => loadSessionData(selectedSession.id)} />
+                                        <ChatInterface
+                                            sessionId={selectedSession.id}
+                                            blobs={blobs}
+                                            onRefreshBlobs={() => loadSessionData(selectedSession.id)}
+                                            initialMessage={THREE_JS_SYSTEM_PROMPT}
+                                        />
                                     </div>
                                 </div>
                             ) : (


### PR DESCRIPTION
Implemented a feature to allow the AI model to generate and render 3D figures using Three.js within the chat interface.

Changes:
1.  **`src/components/ThreeJSRenderer.tsx`**: New component that renders a sandboxed iframe with Three.js loaded from CDN. It executes the provided user code safely.
2.  **`src/components/ChatInterface.tsx`**: Updated to parse markdown code blocks. If a block looks like Three.js code, it renders the `ThreeJSRenderer` below it. Added `initialMessage` prop for system prompting.
3.  **`src/pages/SessionsPage.tsx`**: Added `THREE_JS_SYSTEM_PROMPT` constant and passed it to `ChatInterface` to seed the conversation with 3D generation instructions.

Verification:
- Ran `npm run test` (Cypress) to ensure no regressions in existing flows.
- Validated build success.
- Addressed code review feedback regarding security (XSS) and resource leaks by switching to an iframe implementation.

---
*PR created automatically by Jules for task [14338599609583731070](https://jules.google.com/task/14338599609583731070) started by @nathanalam*